### PR TITLE
More improvements

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,6 +3,12 @@ Options -Indexes
 AddCharset UTF-8 .html
 AddCharset UTF-8 .php
 
+# Protect important files just in case the server goes nuts
+RedirectMatch 403 /settings(\.default)?\.php$
+RedirectMatch 403 /inc/
+RedirectMatch 403 /\.git/
+RedirectMatch 403 /\.gitignore$
+
 <IfModule mod_headers.c>
 Header unset ETag
 <Files *.html>

--- a/inc/html.php
+++ b/inc/html.php
@@ -273,21 +273,24 @@ EOF;
 }
 
 function rebuildIndexes() {	
-	$page = 0; $i = 0; $htmlposts = '';
+	$page = 0; $i = 0;
 	$threads = allThreads(); 
 	$pages = ceil(count($threads) / TINYIB_THREADSPERPAGE) - 1;
 	
 	foreach ($threads as $thread) {
 		$replies = postsInThreadByID($thread['id']);
-		$thread['omitted'] = max(0, count($replies) - TINYIB_PREVIEWREPLIES - 1);
-		
+		$replyCount = count($replies);
+		$repliesInPreview = min($replyCount, TINYIB_PREVIEWREPLIES + 1); // + 1 because the parent is included too
+		$thread['omitted'] = $replyCount - $repliesInPreview;
+
+		$htmlposts = buildPost($thread, TINYIB_INDEXPAGE);
+
 		// Build replies for preview
-		$htmlreplies = array();
-		for ($j = count($replies) - 1; $j > $thread['omitted']; $j--) {
-			$htmlreplies[] = buildPost($replies[$j], TINYIB_INDEXPAGE);
+		for ($j = 1; $j < $repliesInPreview; $j++) { // $replies[0] is parent, so we skip it
+			$htmlposts .= buildPost($replies[$j], TINYIB_INDEXPAGE);
 		}
 		
-		$htmlposts .= buildPost($thread, TINYIB_INDEXPAGE) . implode('', array_reverse($htmlreplies)) . "<br clear=\"left\">\n<hr>";
+		$htmlposts .= "<br clear=\"left\">\n<hr>";
 		
 		if (++$i >= TINYIB_THREADSPERPAGE) {
 			$file = ($page == 0) ? 'index.html' : $page . '.html';


### PR DESCRIPTION
I have fixed the wrong ordering in index files without the usage of arrays (so the server does not have to reverse the array and implode it, which is slower). I were intentionally showing them in descendant order because the 2d2c95d commit showed them that way.

I have also added an additional level of security by blocking "inc" files and settings.php, so nobody will be able to see the password even if the server, for whatever reason, stops parsing PHP files. I have blocked the ".git" folder too, just in case it contains private stuff.
